### PR TITLE
Adding Absolute Zero DK legendary stun

### DIFF
--- a/DRData-1.0.lua
+++ b/DRData-1.0.lua
@@ -1,5 +1,5 @@
 local major = "DRData-1.0"
-local minor = 1070
+local minor = 1080
 assert(LibStub, string.format("%s requires LibStub.", major))
 
 local Data = LibStub:NewLibrary(major, minor)
@@ -294,6 +294,7 @@ local spellsAndProvidersByCategory = {
 		[ 91800] = true, -- Gnaw (Ghoul)
 		[ 91797] = true, -- Monstrous Blow (Dark Transformation Ghoul)
 		[207171] = true, -- Winter is Coming (Remorseless winter stun)
+		[334693] = true, -- Absolute Zero (Frostwyrm's Fury Legendary)
 		-- Demon Hunter
 		[179057] = true, -- Chaos Nova
 		[200166] = true, -- Metamorphosis


### PR DESCRIPTION
Frost DK's have a legendary 
https://www.wowhead.com/spell=334692/absolute-zero
It says "frozen" in the tooltip but its actually a stun.(here is the spell effect it applies https://www.wowhead.com/spell=334693/absolute-zero)
